### PR TITLE
Add Dropbox suuport

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You may directly download the [alfred2-ruby-template workflow]( https://github.c
 
 ### Step 1: Clone or Fork
 
-Clone or fork this repo to your local directory: 
+Clone or fork this repo to your local directory:
 
 `git clone https://github.com/zhaocai/alfred2-ruby-template.git`
 
@@ -89,12 +89,15 @@ Update **domain** and **id** in the `config.yml` file.
 path: workflow
 domain: your.domain
 id: alfred2-ruby-template
+# If you are using Alfred's advanced Dropbox sync, indicate the path shown in
+# Alfred Preferences > Advanced > Syncing:
+dropbox: ~/Dropbox/Alfred
 ```
 
 ### Step 3: Install
 > `[sudo] gem install plist` if you have not installed the **plist** gem.
 
-Run `rake install` to install the workflow. Now you can see the workflow loaded in the
+Run `rake install` to install the workflow or `rake dbxinstall` if you are using Alfred's advanced Dropbox sync. Now you can see the workflow loaded in the
 Alfred workflow interface.
 
 ### Step 4: Add Ruby Gems
@@ -147,7 +150,7 @@ Alfred.with_friendly_error do |alfred|
   if !is_refresh and fb = alfred.feedback.get_cached_feedback
     # cached feedback is valid
     puts fb.to_alfred
-  else 
+  else
     fb = alfred.feedback
     # ... generate_feedback as usually
     fb.put_cached_feedback

--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,10 @@ config_file = 'config.yml'
 
 workflow_home=File.expand_path("~/Library/Application Support/Alfred 2/Alfred.alfredpreferences/workflows")
 
-
 $config = YAML.load_file(config_file)
 $config["bundleid"] = "#{$config["domain"]}.#{$config["id"]}"
 $config["plist"] = File.join($config["path"], "info.plist")
+$config["workflow_dbx"] = File.join(File.expand_path($config["dropbox"]), "/Alfred.alfredpreferences/workflows")
 
 # import sub-rakefiles
 FileList['*/Rakefile'].each { |file|
@@ -59,8 +59,15 @@ task :uninstall => [:config] do
   rm File.join(workflow_home, $config["bundleid"])
 end
 
+desc "Install to Dropbox"
+task :dbxinstall => [:config] do
+  ln_sf File.expand_path($config["path"]), File.join($config["workflow_dbx"], $config["bundleid"])
+end
 
-
+desc "Unlink from Dropbox"
+task :dbxuninstall => [:config] do
+  rm File.join($config["workflow_dbx"], $config["bundleid"])
+end
 
 desc "Clean up all the extras"
 task :clean => [:config] do

--- a/config.yml
+++ b/config.yml
@@ -4,4 +4,6 @@
 path: workflow
 domain: me.zhaowu
 id: alfred2-ruby-template
-
+# If you are using Alfred's advanced Dropbox sync, indicate the path shown in
+# Alfred Preferences > Advanced > Syncing:
+dropbox: ~/Dropbox/Alfred


### PR DESCRIPTION
Hi,

If someone uses Alfred's advanced Dropbox sync, rake install and uninstall are useless.
Proposed fix is adding rake dbxinstall and rake dbxuninstall.

Would you consider this suggestion?

Regards,
