### PR TITLE
Mavericks (Ruby v2) adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A template for Ruby-based Alfred 2 workflow development.
 
 ```ruby
 require 'rubygems' unless defined? Gem
-require "bundle/bundler/setup"
+require_relative "bundle/bundler/setup"
 require "alfred"
 
 Alfred.with_friendly_error do |alfred|
@@ -47,7 +47,7 @@ One more example with rescue feedback automatically generated!
 
 ```ruby
 require 'rubygems' unless defined? Gem
-require "bundle/bundler/setup"
+require_relative "bundle/bundler/setup"
 require "alfred"
 
 def my_code_with_something_goes_wrong
@@ -95,9 +95,11 @@ dropbox: ~/Dropbox/Alfred
 ```
 
 ### Step 3: Install (with System Ruby /usr/bin/ruby)
-If you use rvm or rbenv, switch to the system ruby.
+If you use rvm or rbenv, switch to the system ruby, or call system ruby directly as in ```/usr/bin/ruby```.
 
 > `sudo gem install plist` if you have not installed the **plist** gem.
+
+> `sudo gem install bundler` if you have not installed the **bundler** gem.
 
 Run `rake install` to install the workflow or `rake dbxinstall` if you are using Alfred's advanced Dropbox sync. Now you can see the workflow loaded in the
 Alfred workflow interface.
@@ -126,7 +128,7 @@ Now you are good to add your own code based on the previous example.
 ### 1. Automate saving and loading cached feedback
 ```ruby
 require 'rubygems' unless defined? Gem
-require "bundle/bundler/setup"
+require_relative "bundle/bundler/setup"
 require "alfred"
 
 Alfred.with_friendly_error do |alfred|

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ end
 
 desc "Install Gems"
 task "bundle:install" => [:chdir] do
-  sh %Q{bundle install --standalone --clean} do |ok, res|
+  sh %Q{/usr/bin/bundle install --standalone --clean} do |ok, res|
     if ! ok
       puts "fail to install gems (status = #{res.exitstatus})"
     end
@@ -42,7 +42,7 @@ end
 
 desc "Update Gems"
 task "bundle:update" => [:chdir] do
-  sh %Q{bundle update && bundle install --standalone --clean} do |ok, res|
+  sh %Q{/usr/bin/bundle update && /usr/bin/bundle install --standalone --clean} do |ok, res|
     if ! ok
       puts "fail to update gems (status = #{res.exitstatus})"
     end

--- a/config.yml
+++ b/config.yml
@@ -6,4 +6,4 @@ domain: me.zhaowu
 id: alfred2-ruby-template
 # If you are using Alfred's advanced Dropbox sync, indicate the path shown in
 # Alfred Preferences > Advanced > Syncing:
-dropbox: ~/Dropbox/Alfred
+dropbox: ~/Dropbox

--- a/workflow/main.rb
+++ b/workflow/main.rb
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 require 'rubygems' unless defined? Gem # rubygems is only needed in 1.8
-require "bundle/bundler/setup"
+require_relative "bundle/bundler/setup"
 require "alfred"
 
 
@@ -40,6 +40,3 @@ Alfred.with_friendly_error do |alfred|
 
   puts fb.to_xml(ARGV)
 end
-
-
-

--- a/workflow/main_with_rescue_feedback.rb
+++ b/workflow/main_with_rescue_feedback.rb
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 require 'rubygems' unless defined? Gem
-require "bundle/bundler/setup"
+require_relative "bundle/bundler/setup"
 require "alfred"
 
 
@@ -19,6 +19,3 @@ Alfred.with_friendly_error do |alfred|
     raise Alfred::NoBundleIDError, "Wrong Bundle ID Test!"
   end
 end
-
-
-


### PR DESCRIPTION
Hi!
Loved your ruby template! I'm using a fork for my own workflows :)

The thing was for me that it didn't work quite well with Ruby v2 on mavericks, which makes sense since Mavericks wasn't around 5 months ago, hehe. Lucky for me, it helped me to understand a lot more about ruby, gems, environment, and specially native extensions.

I've made chances to make it work in Mavericks, though I don't know if it will work correctly on previous versions, specifically with Ruby 1.8.7.

Basically I: 
- changed require for require_relatve in the bundler setup require
- changed bundle call for /usr/bin/bundle to have the gems that use native extension to work correctly on Ruby that gets shipped with Mavericks
- changed the documentation to match both this changes

Hope you like it!
Cheers
