### PR TITLE
Updating alfred-workflow gem

### DIFF
--- a/workflow/Gemfile.lock
+++ b/workflow/Gemfile.lock
@@ -1,9 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    alfred-workflow (1.8.0)
+    alfred-workflow (2.0.5)
+      fuzzy_match (>= 2.0.4)
+      gyoku (>= 1.1.0)
+      moneta (>= 0.7.19)
+      nori (>= 2.3.0)
       plist (>= 3.1.0)
-    plist (3.1.0)
+      terminal-notifier (>= 1.5.0)
+    builder (3.2.2)
+    fuzzy_match (2.1.0)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
+    moneta (0.8.0)
+    nori (2.6.0)
+    plist (3.2.0)
+    terminal-notifier (1.6.3)
 
 PLATFORMS
   ruby
@@ -11,3 +23,6 @@ PLATFORMS
 DEPENDENCIES
   alfred-workflow
   plist
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
I was looking through the examples online, and there were some classes used that my ruby template didn't contain. 

It took me a while to find out, that the contained alfred-workflow gem was a little older. 

I suggest to update the bundled version. 
