### PR TITLE
Need require_relative to find bundle

### DIFF
--- a/workflow/main.rb
+++ b/workflow/main.rb
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 require 'rubygems' unless defined? Gem # rubygems is only needed in 1.8
-require "bundle/bundler/setup"
+require_relative 'bundle/bundler/setup'
 require "alfred"
 
 
@@ -22,7 +22,7 @@ Alfred.with_friendly_error do |alfred|
     :arg      => "A test feedback Item" ,
     :valid    => "yes"                  ,
   })
-  
+
   # add an feedback to test rescue feedback
   fb.add_item({
     :uid          => ""                     ,

--- a/workflow/main_with_rescue_feedback.rb
+++ b/workflow/main_with_rescue_feedback.rb
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 require 'rubygems' unless defined? Gem
-require "bundle/bundler/setup"
+require_relative 'bundle/bundler/setup'
 require "alfred"
 
 


### PR DESCRIPTION
On my machines (all Yosemite only) I need to require_relative for the script to find the bundle. 

I am not sure how this worked before and what changed (in my case) to break this. 

I don't have old system to test on though. Not sure if something could break there. 
